### PR TITLE
chore: 🐝 Update SDK - Generate 0.5.2

### DIFF
--- a/package/.speakeasy/workflow.lock
+++ b/package/.speakeasy/workflow.lock
@@ -2,19 +2,20 @@ speakeasyVersion: 1.492.0
 sources:
     petstore-oas:
         sourceNamespace: petstore-oas-123
-        sourceRevisionDigest: sha256:c5aeb8f7b74b6a625d24d84b207e5d91ad39ab39fd80fa1188e592336c966bde
+        sourceRevisionDigest: sha256:ef373c09c5b63fc895460f48ecd5c8704bffdf0bbb7be16e7e5767fa133cb7cf
         sourceBlobDigest: sha256:1abad1a8292d1c78d369392b88aa5fde3e3d2bd97d03adf3d599810f5eccb229
         tags:
             - latest
+            - speakeasy-sdk-regen-1739494111
             - 4.0.0
 targets:
     petstore:
         source: petstore-oas
         sourceNamespace: petstore-oas-123
-        sourceRevisionDigest: sha256:c5aeb8f7b74b6a625d24d84b207e5d91ad39ab39fd80fa1188e592336c966bde
+        sourceRevisionDigest: sha256:ef373c09c5b63fc895460f48ecd5c8704bffdf0bbb7be16e7e5767fa133cb7cf
         sourceBlobDigest: sha256:1abad1a8292d1c78d369392b88aa5fde3e3d2bd97d03adf3d599810f5eccb229
         codeSamplesNamespace: petstore-oas123-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:520b41f685dc1707c0a3bf6d831f31064df706737e1cd2fe05afdd9f23c96e4b
+        codeSamplesRevisionDigest: sha256:499bb6c0c2f00b43391131dfdd6684fea6b4d6a9edabc8f8c44112d112f47b03
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/package/sdk/.speakeasy/gen.lock
+++ b/package/sdk/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: 4.0.0
   speakeasyVersion: 1.492.0
   generationVersion: 2.512.4
-  releaseVersion: 0.5.1
-  configChecksum: 242a054bb06f5b377d177a78aa1216e8
+  releaseVersion: 0.5.2
+  configChecksum: ca69d86601c7a8bff5cd0de390604a44
   repoURL: https://github.com/ryan-timothy-albert/test_nested_repo.git
   repoSubDirectory: package/sdk
   installationURL: https://gitpkg.now.sh/ryan-timothy-albert/test_nested_repo/package/sdk

--- a/package/sdk/.speakeasy/gen.yaml
+++ b/package/sdk/.speakeasy/gen.yaml
@@ -19,7 +19,7 @@ generation:
   tests:
     generateNewTests: true
 typescript:
-  version: 0.5.1
+  version: 0.5.2
   additionalDependencies:
     dependencies: {}
     devDependencies: {}

--- a/package/sdk/RELEASES.md
+++ b/package/sdk/RELEASES.md
@@ -288,3 +288,13 @@ Based on:
 - [typescript v0.4.0] package/sdk
 ### Releases
 - [NPM v0.4.0] https://www.npmjs.com/package/ryan-total-test-act/v/0.4.0 - package/sdk
+
+## 2025-02-14 00:48:17
+### Changes
+Based on:
+- OpenAPI Doc  
+- Speakeasy CLI 1.492.0 (2.512.4) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v0.5.2] package/sdk
+### Releases
+- [NPM v0.5.2] https://www.npmjs.com/package/ryan-total-test-act/v/0.5.2 - package/sdk

--- a/package/sdk/jsr.json
+++ b/package/sdk/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "ryan-total-test-act",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package/sdk/package-lock.json
+++ b/package/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ryan-total-test-act",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ryan-total-test-act",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@types/node": "^18.19.3",

--- a/package/sdk/package.json
+++ b/package/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ryan-total-test-act",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": "ryan-timothy-albert",
   "main": "./index.js",
   "sideEffects": false,

--- a/package/sdk/src/lib/config.ts
+++ b/package/sdk/src/lib/config.ts
@@ -81,7 +81,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "4.0.0",
-  sdkVersion: "0.5.1",
+  sdkVersion: "0.5.2",
   genVersion: "2.512.4",
-  userAgent: "speakeasy-sdk/typescript 0.5.1 2.512.4 4.0.0 ryan-total-test-act",
+  userAgent: "speakeasy-sdk/typescript 0.5.2 2.512.4 4.0.0 ryan-total-test-act",
 } as const;


### PR DESCRIPTION
> [!IMPORTANT]
> Linting report available at: <https://app.speakeasy.com/org/ryan-local/ryan-telemetry/linting-report/b32185f5578978e3d85983c8d0283bf8>
> OpenAPI Change report available at: <https://app.speakeasy.com/org/ryan-local/ryan-telemetry/changes-report/a6feb8384439c609cf0b81b17158d920>
# SDK update
Based on:
- OpenAPI Doc  
- Speakeasy CLI 1.492.0 (2.512.4) https://github.com/speakeasy-api/speakeasy
## Versioning

Version Bump Type: [patch] - 🤖 (automated)
## OpenAPI Change Summary
No specification changes

## TYPESCRIPT CHANGELOG
No relevant generator changes

